### PR TITLE
Fix/upgrade ingress api version

### DIFF
--- a/examples/blue-green/bluegreen-ingress.yaml
+++ b/examples/blue-green/bluegreen-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: bluegreen-demo

--- a/examples/blue-green/bluegreen-preview-ingress.yaml
+++ b/examples/blue-green/bluegreen-preview-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: bluegreen-demo-preview


### PR DESCRIPTION
Update the apiversion of ingress objects. 
The apiversion `networking.k8s.io/v1beta1` was deprecated in k8s v1.22. The latest apiversion (`networking.k8s.io/v1`) was released in v1.19.

Ir order to can deploy in k8s clusters from v1.22 we must change the apiversion.